### PR TITLE
[codex] tighten homepage, CV, and writing positioning

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,8 +5,6 @@ project:
     - "posts/**/*.qmd"
     - "consulting/**/*.qmd"
     - "randomposts/**/*.qmd"
-    - "!benchmark_usage_metrics_2.md"
-    - "!optimization_tutorial.md"
 
 website:
   title: "Farrukh Nauman"

--- a/consulting.qmd
+++ b/consulting.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Selected Work"
-subtitle: "Enterprise data platforms, warehouse optimization, analytics automation, and time series ML"
+subtitle: "Enterprise data platforms, warehouse optimization, AI agents, and time series"
 description: "Problems I solve, how I work, and selected examples from enterprise data consulting engagements."
 toc: false
 format:

--- a/consulting.qmd
+++ b/consulting.qmd
@@ -26,10 +26,6 @@ Your analytics team spends too much time on repetitive notebook runs, manual SQL
 
 You have sensor, telemetry, or time series data and need production ML — activity recognition, anomaly detection, forecasting, or classification. I specialize in approaches that are fast enough for edge and IoT deployment (ROCKET family, lightweight models) while maintaining state-of-the-art accuracy. I work from evaluation harness to production, not just research prototypes.
 
-### Multimodal inspection and quality assessment
-
-You need automated visual inspection or quality assessment — garment grading, defect detection, or similar classification-from-images problems. I have delivered end-to-end systems including data collection pipelines, synthetic data generation, model training, and pilot deployment in industrial settings.
-
 
 ## How I work
 
@@ -37,7 +33,7 @@ You need automated visual inspection or quality assessment — garment grading, 
 
 **Embedded principal / interim lead** — I join your team for weeks or months. I own deliverables, coordinate with stakeholders, manage a roadmap, and ship production work alongside your people.
 
-**Hands-on implementation** — I build the thing: validation frameworks, optimization benchmarks, coding-agent workflows, time series models, inspection pipelines. I write code, not slide decks.
+**Hands-on implementation** — I build the thing: validation frameworks, optimization benchmarks, coding-agent workflows, and time series models. I write code, not slide decks.
 
 **Evaluation-first delivery** — Every engagement starts with a clear success criterion and a way to measure it. I do not optimize until I can prove correctness. I do not ship until I can show evidence.
 
@@ -78,14 +74,6 @@ Delivered a time series classification system for industrial telemetry with stat
 [Read more](consulting/2025-11-01-Time-Series-Classification/index.qmd){.btn .btn-sm .btn-outline-primary .mt-2}
 :::
 
-::: {.g-col-12 .g-col-md-6 .work-card}
-### Automated Inspection for Circular Fashion
-
-End-to-end AI system for second-hand garment quality assessment: object detection, synthetic data generation, and pilot deployment. Led two EU-funded initiatives delivering 40% faster processing and 50%+ reduction in data collection effort.
-
-[Read more](consulting/2025-04-13-AI-fashion/index.qmd){.btn .btn-sm .btn-outline-primary .mt-2}
-:::
-
 :::
 
 
@@ -96,7 +84,7 @@ You should reach out if:
 - You are a **data platform or data engineering leader** dealing with a migration, cost problem, or analytics modernization.
 - You are a **technical sponsor or architect** who needs a senior practitioner to lead or unblock a workstream.
 - You need an **interim team lead** who can own a roadmap, manage stakeholders, and still write code.
-- You have a **time series, telemetry, or inspection problem** that needs production ML, not a research paper.
+- You have a **time series or telemetry problem** that needs production ML, not a research paper.
 
 I typically work with enterprise teams in manufacturing, logistics, energy, and industrial IoT — but the methods transfer.
 

--- a/contact.qmd
+++ b/contact.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Work With Me"
-subtitle: "Enterprise data platforms, warehouse optimization, analytics automation, time series ML"
-description: "Get in touch about migration assurance, warehouse cost and performance work, analytics automation with coding agents, or time series ML."
+subtitle: "Enterprise data platforms, warehouse optimization, AI agents, time series"
+description: "Get in touch about migration assurance, warehouse cost and performance work, analytics automation with AI agents, or time series."
 toc: false
 format:
   html:
@@ -29,7 +29,10 @@ I work with enterprise data teams on problems where the gap between "we have dat
 ## Get in touch
 
 [Email me](mailto:farrukh.nauman@inertialrange.com){.btn .btn-primary .btn-lg}
+[Connect on LinkedIn](https://www.linkedin.com/in/fnauman/){.btn .btn-outline-primary .btn-lg}
 
-If you reach out, include a short note on the migration, cost, automation, or telemetry problem you are working on.
+I usually reply within 1–2 business days. If you reach out, a line or two on what you are working on helps me prepare a useful first response:
 
-Or connect on [LinkedIn](https://www.linkedin.com/in/fnauman/).
+::: {.intake-topics .mt-3}
+`migration` · `warehouse cost` · `analytics automation` · `AI agents` · `time series` · `interim leadership` · `something else`
+:::

--- a/cv.qmd
+++ b/cv.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Farrukh Nauman" 
-subtitle: "Principal AI Consultant | Agentic Decision Systems | Time Series & LLMs | PhD"
+subtitle: "Principal AI Consultant | Enterprise Data Platforms · Agentic Decision Systems · Time Series | PhD"
 resources: 
   - assets/FarrukhNauman_brokers.pdf
 toc: false
@@ -24,30 +24,25 @@ Github: [fnauman](https://github.com/fnauman) |
 
 ---
 
-## Value Proposition
+## Summary
 
-Principal consultant and interim team lead bridging strategy and hands-on delivery in production-scale data environments (telemetry/time series, vision, and LLM workflow automation). Selected outcomes from applied R&D / pilot deployments:
+Principal consultant helping enterprise data teams de-risk platform migrations, cut warehouse cost, and automate analytics workflows with coding agents. I lead and ship in production-scale environments — owning roadmaps, managing stakeholders, and writing code, not slide decks. Selected results:
 
-- 40% faster textile quality assessment workflow (pilot).
-- 50%+ reduction in data collection/labeling effort via synthetic data (pilot).
-- Up to 90% lower edge hardware cost enabled by low-energy ML approach (prototype).
-
-## Leadership Highlights
-
-- Interim Team Lead for Data Science & Advanced Analytics (4-7 person) at a global industrial telemetry, roadmap ownership and stakeholder management.
-- Led applied AI initiatives at RISE: [Vinnova](https://www.ri.se/en/what-we-do/projects/ai-for-resource-efficient-circular-fashion) (Project Lead, ~9M SEK) and [CISUTAC](https://www.cisutac.eu/) (AI Lead, ~2M SEK), delivering pilot-ready systems and public artifacts. 
-- Scaled delivery practices: evaluation-first approach, privacy-aware workflows, requirements → success criteria → handover.
-- Established and led an AI mentorship program for Master's thesis students, resulting in 4 industry-applicable projects.
+- **5–10x faster** pipeline with row-level correctness proof after killing a broken optimization.
+- **~1 week** from zero to live cross-platform migration validation dashboard.
+- **40% faster** quality-assessment workflow via end-to-end AI pilot.
+- **Interim team lead** for a 4–7 person DS & analytics team at a global industrial manufacturer.
 
 ## Skills & Tech Stack
 
 | Area | Skills |
 |------|--------|
-| **AI & ML** | **LLMs**: Text-to-SQL, RAG, Fine-tuning, Evaluation Harnesses, Synthetic Data, Logging & Reliability Analysis;<br>**Vision**: Object Detection, Classification, Segmentation, Inspection workflows, Edge AI;<br>**Time Series**: Forecasting, Anomaly Detection, Activity Recognition, Predictive Maintenance; |
-| **MLOps & Cloud** | Snowflake, Snowpark, Databricks/Spark, Streamlit, Docker, CI/CD, Model Monitoring, Experiment Tracking, Azure ML |
+| **Data Platforms** | Snowflake, Snowpark, Databricks/Spark, Azure Data Factory, cross-platform migration validation, incremental pipeline design, warehouse cost profiling |
+| **AI Coding Agents** | Cortex Code, Codex CLI, Claude Code; agent-assisted migration, validation, and pipeline optimization; `AGENTS.md`-based quality contracts |
+| **Time Series & Telemetry ML** | Activity Recognition, Anomaly Detection, Forecasting, Predictive Maintenance, ROCKET family, edge/IoT deployment |
+| **ML & AI** | LLMs (Text-to-SQL, RAG, evaluation harnesses, synthetic data); Vision (detection, classification, inspection); Experiment Tracking, Model Monitoring |
 | **Programming** | Python (Expert), SQL, C/C++, High Performance Computing, LangChain, OpenAI SDK |
-| **AI Coding Agents** | Cortex Code, Codex CLI, Claude Code; agent-assisted migration, validation, and pipeline optimization workflows |
-| **Leadership & Delivery** | Stakeholder Management, Requirements Gathering, Roadmapping, Solution Architecture, Technical Leadership, Governance, ROI Analysis, Client Communication |
+| **Leadership & Delivery** | Stakeholder Management, Roadmapping, Solution Architecture, Evaluation-First Delivery, Governance, Client Communication |
 | **Languages** | English (Fluent), Swedish (SFI C2), Urdu (Native) |
 
 ## Experience
@@ -78,13 +73,6 @@ Client: Global Industrial Manufacturer (Material Handling & Logistics)
 - **Pilot Outcomes**: 40% faster processing and 50%+ reduction in data collection effort via synthetic data.
 - **Recognition**: 1 of only 5 projects presented at [EU sustainable AI](https://swedish-presidency.consilium.europa.eu/en/events/event-on-sustainable-artificial-intelligence-ai-2-35/) (2023) and Vinnova Innovation week (2022).
 - **Deliverables**: Pilot-ready AI system, [Annotated public dataset](https://zenodo.org/records/13788681), [Roadmap for industry adoption](https://fnauman.github.io/second-hand-fashion/posts/2025-04-08-roadmap-to-full-automation/).
-
-**Project: LLM Implementation for Regional Textile Recycling Network (2024-2025: *4 months*)**:
-
-- **Challenge**: Clients needed to integrate LLMs into their networking platform for textile recycling in Europe.
-- **Solution**: Designed a evaluation driven RAG solution for both structured and unstructured data.
-- **Impact**: Enabled a smart search and retrieval system for connecting textile actors in Europe.
-- **Technologies**: Retrieval Augmented Generation, LangChain, Evaluations, Prompt Engineering, Synthetic Data.
 
 **Project: Low Energy IoT Solutions for Industrial Clients (2022: *4 months*)**:
 

--- a/cv.qmd
+++ b/cv.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Farrukh Nauman" 
-subtitle: "Principal AI Consultant | Enterprise Data Platforms · Agentic Decision Systems · Time Series | PhD"
+subtitle: "Principal Consultant | Enterprise Data Platforms · Coding Agents · Time Series ML | PhD"
 resources: 
   - assets/FarrukhNauman_brokers.pdf
 toc: false
@@ -30,20 +30,16 @@ Principal consultant helping enterprise data teams de-risk platform migrations, 
 
 - **5–10x faster** pipeline with row-level correctness proof after killing a broken optimization.
 - **~1 week** from zero to live cross-platform migration validation dashboard.
-- **40% faster** quality-assessment workflow via end-to-end AI pilot.
+- **10-100x faster** telemetry classification inference than deep learning baselines for industrial deployment.
 - **Interim team lead** for a 4–7 person DS & analytics team at a global industrial manufacturer.
 
-## Skills & Tech Stack
+## Current focus
 
-| Area | Skills |
-|------|--------|
-| **Data Platforms** | Snowflake, Snowpark, Databricks/Spark, Azure Data Factory, cross-platform migration validation, incremental pipeline design, warehouse cost profiling |
-| **AI Coding Agents** | Cortex Code, Codex CLI, Claude Code; agent-assisted migration, validation, and pipeline optimization; `AGENTS.md`-based quality contracts |
-| **Time Series & Telemetry ML** | Activity Recognition, Anomaly Detection, Forecasting, Predictive Maintenance, ROCKET family, edge/IoT deployment |
-| **ML & AI** | LLMs (Text-to-SQL, RAG, evaluation harnesses, synthetic data); Vision (detection, classification, inspection); Experiment Tracking, Model Monitoring |
-| **Programming** | Python (Expert), SQL, C/C++, High Performance Computing, LangChain, OpenAI SDK |
-| **Leadership & Delivery** | Stakeholder Management, Roadmapping, Solution Architecture, Evaluation-First Delivery, Governance, Client Communication |
-| **Languages** | English (Fluent), Swedish (SFI C2), Urdu (Native) |
+- Cross-platform migration validation and warehouse modernization in Snowflake / Databricks environments.
+- Coding-agent workflows for migration, validation, analytics automation, and large code changes.
+- Time series / telemetry ML for industrial production and edge deployment.
+- Interim technical leadership: roadmap ownership, stakeholder steering, delivery discipline, and hands-on implementation.
+- Core stack: Python, SQL, Snowflake, Databricks/Spark, Azure Data Factory, Streamlit, PyTorch, LangChain, OpenAI SDK.
 
 ## Experience
 
@@ -66,32 +62,10 @@ Client: Global Industrial Manufacturer (Material Handling & Logistics)
 **AI Researcher & Consultant**  
 *Jul 2021 - Aug 2025* | Linköping, Sweden
 
-**Project Lead: Sustainable Fashion AI Automation (2022-2025: *24 months*)**: Leading two major initiatives in sustainable fashion: [Vinnova: AI for Circular Fashion](https://www.ri.se/en/what-we-do/projects/ai-for-resource-efficient-circular-fashion) (Project Lead, ~9M SEK) and [CISUTAC](https://www.cisutac.eu/) (AI Lead, ~2M SEK).
-
-- **Challenge**: Manual quality inspection created bottlenecks in circular fashion supply chains due to inconsistent assessments and high labor cost.
-- **Delivery**: Led end-to-end delivery of an automated attribute detection system spanning data collection/annotation pipeline, dataset curation, model training/optimization, synthetic data generation, and pilot deployment/validation.
-- **Pilot Outcomes**: 40% faster processing and 50%+ reduction in data collection effort via synthetic data.
-- **Recognition**: 1 of only 5 projects presented at [EU sustainable AI](https://swedish-presidency.consilium.europa.eu/en/events/event-on-sustainable-artificial-intelligence-ai-2-35/) (2023) and Vinnova Innovation week (2022).
-- **Deliverables**: Pilot-ready AI system, [Annotated public dataset](https://zenodo.org/records/13788681), [Roadmap for industry adoption](https://fnauman.github.io/second-hand-fashion/posts/2025-04-08-roadmap-to-full-automation/).
-
-**Project: Low Energy IoT Solutions for Industrial Clients (2022: *4 months*)**:
-
-- **Challenge**: Clients needed to process sensor data at the edge with limited energy, preventing real-time analysis.
-- **Solution**: Identified energy-efficient AI algorithms (miniROCKET algorithm) for edge devices that is faster than deep learning methods by over 2000x.
-- **Impact**: Enabled real-time sensor data analysis with 90% lower hardware costs.
-- **Technologies**: Edge AI, Time Series Classification, Anomaly Detection, Low-Energy Computing.
-
-**AI Mentorship Program (2023-2024)**: Established and led mentorship program for Master's thesis students in AI, resulting in 4 industry-applicable projects.
-
-- **Projects**: Damage Detection in Fashion, Generative AI for Fashion, Time Series Forecasting for Fashion Trends, Image Embeddings for Second-Hand Fashion.
-- **Activities**: Provided hands-on training in deep learning and AI for advanced industrial AI application.
-
-**Other Projects**:
-
-- **Aero EDIH (2024)**: Consulted with startups on data/model strategies for on-device drone deployment for vehicle/person detection and runway debris identification. **Tasks**: Object Detection, Edge AI, Diffusion Models.
-- **Ramverk (2024)**: Prepared roadmap for air traffic control automation, including reinforcement learning state-of-the-art models and data collection proposal. **Tasks**: Reinforcement Learning, Data Collection.
-- **GreenerFlow (2023)**: Factor analysis for traffic congestion in metropolitan areas, led consortium formation for a larger project. **Tasks**: Time Series Analysis, Multi-modal Data.
-- **SHOW - Hard Brake Detection (2022)**: Developed time series anomaly detection models to identify hard brakes in autonomous buses. **Tasks**: Time Series Classification, Anomaly Detection.
+- Led applied AI consulting and project delivery across inspection, edge ML, time series, and industrial automation programs.
+- **Sustainable Fashion AI Automation (2022-2025)**: Project lead for [Vinnova: AI for Circular Fashion](https://www.ri.se/en/what-we-do/projects/ai-for-resource-efficient-circular-fashion) and AI lead in [CISUTAC](https://www.cisutac.eu/), delivering an automated quality-assessment workflow with 40% faster processing and 50%+ reduction in data collection effort via synthetic data.
+- **Low-Energy IoT Solutions (2022)**: Identified miniROCKET-based time series methods for industrial edge deployment, enabling real-time analysis with roughly 90% lower hardware cost than heavier alternatives.
+- Established and led an AI mentorship program for Master's thesis students and supported additional client work in drone edge AI, air-traffic automation planning, traffic analysis, and anomaly detection.
 
 ### 2MNordic IT Consulting AB
 **Data Scientist & Data Engineer**  

--- a/index.qmd
+++ b/index.qmd
@@ -1,15 +1,14 @@
 ---
 title: "Farrukh Nauman"
-subtitle: "Enterprise Data Platforms, Coding Agents, and Time Series ML"
 description: "I help enterprise data teams de-risk migrations, cut warehouse cost, and automate analytics workflows with coding agents."
 image: assets/officialpic.JPG
 resources:
   - assets/FarrukhNauman_brokers.pdf
-title-block: false
 body-classes: home-page
 toc: false
 format:
   html:
+    title-block: false
     page-layout: full
 ---
 
@@ -22,17 +21,21 @@ format:
 ::: {.g-col-12 .g-col-md-3 .text-center .order-2 .order-md-1}
 ![](assets/officialpic.JPG){.rounded-circle width=180px}
 
-::: {.d-flex .justify-content-center .gap-3 .mt-3}
-[![GitHub](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs/brands/github.svg){width=22px title="GitHub" .social-icon}](https://github.com/fnauman)
-[![Twitter](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs/brands/twitter.svg){width=22px title="Twitter" .social-icon}](https://twitter.com/naumanf_)
-[![LinkedIn](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs/brands/linkedin.svg){width=22px title="LinkedIn" .social-icon}](https://www.linkedin.com/in/fnauman/)
-[![Email](https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs/regular/envelope.svg){width=22px title="Email" .social-icon}](mailto:farrukh.nauman@inertialrange.com)
+::: {.hero-social .d-flex .justify-content-center .gap-3 .mt-3}
+<a href="https://github.com/fnauman" aria-label="GitHub"><i class="bi bi-github"></i></a>
+<a href="https://twitter.com/naumanf_" aria-label="Twitter"><i class="bi bi-twitter-x"></i></a>
+<a href="https://www.linkedin.com/in/fnauman/" aria-label="LinkedIn"><i class="bi bi-linkedin"></i></a>
+<a href="mailto:farrukh.nauman@inertialrange.com" aria-label="Email"><i class="bi bi-envelope"></i></a>
 :::
 :::
 
 ::: {.g-col-12 .g-col-md-9 .order-1 .order-md-2}
 
-## I help enterprise data teams de-risk migrations, cut warehouse cost, and automate analytics workflows with coding agents. {.hero-headline}
+<h1 class="hero-name">Farrukh Nauman</h1>
+
+<p class="hero-subhead">Enterprise Data Platforms, Coding Agents, and Time Series ML</p>
+
+<p class="hero-headline">I help enterprise data teams de-risk migrations, cut warehouse cost, and automate analytics workflows with coding agents.</p>
 
 Principal consultant with deep experience across enterprise data platforms, time series / telemetry ML, and hands-on AI delivery in messy real-world environments.
 
@@ -65,8 +68,8 @@ SQL pipeline optimization with row-level correctness validation
 :::
 
 ::: {.g-col-6 .g-col-md-3 .text-center .proof-item}
-**40% faster**
-AI-driven quality assessment pilot for circular fashion
+**10-100x faster**
+Time series classification for industrial telemetry and edge deployment
 :::
 
 ::: {.g-col-6 .g-col-md-3 .text-center .proof-item}
@@ -156,14 +159,6 @@ Built a production-grade validation system for a large Databricks-to-Snowflake m
 Delivered a time series classification system for industrial telemetry: state-of-the-art accuracy with 10-100x faster inference than deep learning, designed for edge and IoT deployment.
 
 [Read more](consulting/2025-11-01-Time-Series-Classification/index.qmd){.btn .btn-sm .btn-outline-primary .mt-2}
-:::
-
-::: {.g-col-12 .g-col-md-6 .work-card}
-### Automated Inspection for Circular Fashion
-
-End-to-end AI system for second-hand garment quality assessment: object detection, synthetic data generation, and pilot deployment. 40% faster processing, 50%+ reduction in data collection effort.
-
-[Read more](consulting/2025-04-13-AI-fashion/index.qmd){.btn .btn-sm .btn-outline-primary .mt-2}
 :::
 
 :::

--- a/index.qmd
+++ b/index.qmd
@@ -1,21 +1,12 @@
 ---
-title: "Farrukh Nauman | Enterprise Data Platforms, Coding Agents, and Time Series ML"
+title: "Farrukh Nauman"
+subtitle: "Enterprise Data Platforms, Coding Agents, and Time Series ML"
 description: "I help enterprise data teams de-risk migrations, cut warehouse cost, and automate analytics workflows with coding agents."
 image: assets/officialpic.JPG
 resources:
   - assets/FarrukhNauman_brokers.pdf
 title-block: false
 body-classes: home-page
-listing:
-  - id: featured-writing-listing
-    contents: posts
-    type: grid
-    sort: "date desc"
-    max-items: 2
-    include:
-      featured: true
-    fields: [title, description, date, categories]
-    grid-columns: 2
 toc: false
 format:
   html:
@@ -178,14 +169,27 @@ End-to-end AI system for second-hand garment quality assessment: object detectio
 :::
 
 
-<!-- ───────────────── FEATURED WRITING ───────────────── -->
+<!-- ───────────────── WHO I WORK BEST WITH ───────────────── -->
 
-## Writing {.section-heading .mt-5}
+## Who I work best with {.section-heading .mt-5}
 
-::: {#featured-writing-listing .mt-4}
+::: {.grid .mt-4}
+
+::: {.g-col-12 .g-col-md-4 .fit-card}
+**Data platform & engineering leaders** migrating between warehouses who need systematic validation — not spot-checks and hope.
 :::
 
-[All writing](posts.qmd){.btn .btn-outline-secondary .mt-3}
+::: {.g-col-12 .g-col-md-4 .fit-card}
+**Technical sponsors & architects** who need a senior practitioner to lead or unblock a workstream — someone who owns deliverables, not slide decks.
+:::
+
+::: {.g-col-12 .g-col-md-4 .fit-card}
+**Teams with telemetry or time series data** that need production ML — activity recognition, anomaly detection, or forecasting — not a research paper.
+:::
+
+:::
+
+[More writing on the blog →](posts.qmd){.btn .btn-outline-secondary .mt-4}
 
 
 <!-- ───────────────── FINAL CTA ───────────────── -->

--- a/posts.qmd
+++ b/posts.qmd
@@ -23,7 +23,3 @@ Shorter notes and experiments live in [TIL / Random Notes](randomposts.qmd).
 
 ::: {#all-posts-listing}
 :::
-
----
-
-*For shorter notes and experiments, see [TIL / Random Notes](randomposts.qmd).*

--- a/posts.qmd
+++ b/posts.qmd
@@ -3,15 +3,6 @@ title: "Writing"
 subtitle: "Case studies, technical essays, and notes from applied AI work"
 description: "Technical writing on data platform migrations, coding agents, time series ML, and applied AI."
 listing:
-  - id: featured-posts-listing
-    contents: posts
-    type: grid
-    sort: "date desc"
-    max-items: 2
-    include:
-      featured: true
-    fields: [title, description, date, categories]
-    grid-columns: 2
   - id: all-posts-listing
     contents:
       - posts
@@ -27,17 +18,6 @@ format:
   html:
     page-layout: article
 ---
-
-## Featured writing
-
-Flagship case studies and technical essays sit here. Short notes stay in the archive.
-
-::: {#featured-posts-listing .mt-4}
-:::
-
----
-
-## Archive
 
 ::: {#all-posts-listing}
 :::

--- a/posts.qmd
+++ b/posts.qmd
@@ -1,12 +1,10 @@
 ---
 title: "Writing"
-subtitle: "Case studies, technical essays, and notes from applied AI work"
-description: "Technical writing on data platform migrations, coding agents, time series ML, and applied AI."
+subtitle: "Case studies and technical essays from applied AI delivery"
+description: "Technical writing on data platform migrations, coding agents, warehouse optimization, and time series ML."
 listing:
   - id: all-posts-listing
-    contents:
-      - posts
-      - randomposts
+    contents: posts
     type: default
     sort: "date desc"
     categories: false
@@ -19,9 +17,13 @@ format:
     page-layout: article
 ---
 
+Longer-form case studies and technical essays from enterprise data, coding-agent, and applied ML work live here.
+
+Shorter notes and experiments live in [TIL / Random Notes](randomposts.qmd).
+
 ::: {#all-posts-listing}
 :::
 
 ---
 
-*Posts tagged `short-note` are quick notes and things I learned. The rest are longer-form essays and case studies.*
+*For shorter notes and experiments, see [TIL / Random Notes](randomposts.qmd).*

--- a/theme-dark.scss
+++ b/theme-dark.scss
@@ -127,7 +127,7 @@ a {
     font-size: 0.95rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: darken($body-color, 28%);
+    color: rgba($body-color, 0.68);
     margin-bottom: 1rem;
   }
 
@@ -142,7 +142,7 @@ a {
 
   p {
     font-size: 0.98rem;
-    color: darken($body-color, 18%);
+    color: rgba($body-color, 0.82);
     line-height: 1.55;
     max-width: 58ch;
   }
@@ -154,7 +154,7 @@ a {
 
 .hero-social {
   a {
-    color: darken($body-color, 12%);
+    color: rgba($body-color, 0.85);
     font-size: 1.15rem;
     text-decoration: none;
   }
@@ -184,7 +184,7 @@ a {
     }
 
     font-size: 0.9rem;
-    color: darken($body-color, 12%);
+    color: rgba($body-color, 0.82);
     line-height: 1.35;
   }
 }
@@ -263,7 +263,7 @@ h2.section-heading {
   p {
     font-size: 0.95rem;
     line-height: 1.5;
-    color: darken($body-color, 10%);
+    color: rgba($body-color, 0.85);
     margin-bottom: 1rem;
   }
 
@@ -297,14 +297,14 @@ h2.section-heading {
 
   p {
     font-size: 0.88rem;
-    color: darken($body-color, 15%);
+    color: rgba($body-color, 0.75);
     line-height: 1.45;
     margin-bottom: 0.25rem;
   }
 
   em {
     font-size: 0.82rem;
-    color: darken($body-color, 25%);
+    color: rgba($body-color, 0.6);
   }
 }
 
@@ -352,13 +352,13 @@ h2.section-heading {
 
     .listing-description {
       font-size: 0.95rem;
-      color: darken($body-color, 10%);
+      color: rgba($body-color, 0.85);
       line-height: 1.55;
     }
 
     .listing-date {
       font-size: 0.85rem;
-      color: darken($body-color, 22%);
+      color: rgba($body-color, 0.65);
       margin-top: auto;
       order: -1;
       margin-bottom: 0.7rem;
@@ -392,7 +392,7 @@ h2.section-heading {
   }
 
   font-size: 0.95rem;
-  color: darken($body-color, 10%);
+  color: rgba($body-color, 0.85);
   line-height: 1.5;
 }
 
@@ -421,14 +421,14 @@ h2.section-heading {
 
   p {
     font-size: 0.88rem;
-    color: darken($body-color, 15%);
+    color: rgba($body-color, 0.75);
     line-height: 1.45;
     margin-bottom: 0.25rem;
   }
 
   em {
     font-size: 0.82rem;
-    color: darken($body-color, 25%);
+    color: rgba($body-color, 0.6);
   }
 }
 
@@ -445,7 +445,7 @@ h2.section-heading {
   }
 
   font-size: 0.95rem;
-  color: darken($body-color, 10%);
+  color: rgba($body-color, 0.85);
 }
 
 // ─── Final CTA ───
@@ -466,7 +466,7 @@ h2.section-heading {
 
   p {
     font-size: 1.1rem;
-    color: darken($body-color, 10%);
+    color: rgba($body-color, 0.85);
   }
 }
 

--- a/theme-dark.scss
+++ b/theme-dark.scss
@@ -115,7 +115,23 @@ a {
 .hero-section {
   padding: 2.25rem 0 2rem;
 
-  h2.hero-headline {
+  h1.hero-name {
+    font-size: 2.35rem;
+    line-height: 1.05;
+    color: $headings-color;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+  }
+
+  .hero-subhead {
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: darken($body-color, 28%);
+    margin-bottom: 1rem;
+  }
+
+  .hero-headline {
     font-size: 1.7rem;
     line-height: 1.24;
     color: $headings-color;
@@ -133,6 +149,18 @@ a {
 
   .btn {
     min-width: 9.5rem;
+  }
+}
+
+.hero-social {
+  a {
+    color: darken($body-color, 12%);
+    font-size: 1.15rem;
+    text-decoration: none;
+  }
+
+  a:hover {
+    color: $primary;
   }
 }
 
@@ -537,7 +565,11 @@ blockquote {
   .hero-section {
     padding: 1rem 0 1.5rem;
 
-    h2.hero-headline {
+    h1.hero-name {
+      font-size: 2rem;
+    }
+
+    .hero-headline {
       font-size: 1.45rem;
       max-width: none;
     }

--- a/theme-dark.scss
+++ b/theme-dark.scss
@@ -347,6 +347,79 @@ h2.section-heading {
   }
 }
 
+// ─── Fit cards (Who I work best with) ───
+
+.fit-card {
+  border: 1px solid rgba($primary, 0.12);
+  border-radius: 14px;
+  padding: 1.4rem;
+  background: $card-bg;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  height: 100%;
+
+  strong {
+    color: $primary;
+    display: block;
+    margin-bottom: 0.35rem;
+  }
+
+  font-size: 0.95rem;
+  color: darken($body-color, 10%);
+  line-height: 1.5;
+}
+
+// ─── Writing link cards ───
+
+.writing-link-card {
+  border-left: 3px solid $primary;
+  padding: 1.1rem 1.25rem;
+  background: rgba($primary, 0.04);
+  border-radius: 0 10px 10px 0;
+  height: 100%;
+
+  h3 {
+    font-size: 1rem;
+    margin-top: 0;
+    margin-bottom: 0.4rem;
+    font-weight: 600;
+    line-height: 1.35;
+
+    a {
+      color: $headings-color;
+      text-decoration: none;
+      &:hover { color: $primary; }
+    }
+  }
+
+  p {
+    font-size: 0.88rem;
+    color: darken($body-color, 15%);
+    line-height: 1.45;
+    margin-bottom: 0.25rem;
+  }
+
+  em {
+    font-size: 0.82rem;
+    color: darken($body-color, 25%);
+  }
+}
+
+// ─── Intake topics (contact page) ───
+
+.intake-topics {
+  code {
+    background: rgba($primary, 0.12);
+    color: $primary;
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.88rem;
+    font-weight: 500;
+  }
+
+  font-size: 0.95rem;
+  color: darken($body-color, 10%);
+}
+
 // ─── Final CTA ───
 
 .final-cta {
@@ -485,6 +558,8 @@ blockquote {
 
   .service-card,
   .work-card,
+  .fit-card,
+  .writing-link-card,
   .quarto-listing-grid .quarto-grid-item {
     margin-bottom: 0.75rem;
   }

--- a/theme.scss
+++ b/theme.scss
@@ -318,6 +318,79 @@ h2.section-heading {
   }
 }
 
+// ─── Fit cards (Who I work best with) ───
+
+.fit-card {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 14px;
+  padding: 1.4rem;
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+  height: 100%;
+
+  strong {
+    color: $primary;
+    display: block;
+    margin-bottom: 0.35rem;
+  }
+
+  font-size: 0.95rem;
+  color: lighten($secondary, 10%);
+  line-height: 1.5;
+}
+
+// ─── Writing link cards ───
+
+.writing-link-card {
+  border-left: 3px solid $primary;
+  padding: 1.1rem 1.25rem;
+  background: rgba($primary, 0.015);
+  border-radius: 0 10px 10px 0;
+  height: 100%;
+
+  h3 {
+    font-size: 1rem;
+    margin-top: 0;
+    margin-bottom: 0.4rem;
+    font-weight: 600;
+    line-height: 1.35;
+
+    a {
+      color: $headings-color;
+      text-decoration: none;
+      &:hover { color: $primary; }
+    }
+  }
+
+  p {
+    font-size: 0.88rem;
+    color: lighten($secondary, 15%);
+    line-height: 1.45;
+    margin-bottom: 0.25rem;
+  }
+
+  em {
+    font-size: 0.82rem;
+    color: lighten($secondary, 25%);
+  }
+}
+
+// ─── Intake topics (contact page) ───
+
+.intake-topics {
+  code {
+    background: rgba($primary, 0.08);
+    color: $primary;
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.88rem;
+    font-weight: 500;
+  }
+
+  font-size: 0.95rem;
+  color: lighten($secondary, 10%);
+}
+
 // ─── Final CTA ───
 
 .final-cta {
@@ -443,6 +516,8 @@ h2.section-heading {
 
   .service-card,
   .work-card,
+  .fit-card,
+  .writing-link-card,
   .quarto-listing-grid .quarto-grid-item {
     margin-bottom: 0.75rem;
   }

--- a/theme.scss
+++ b/theme.scss
@@ -85,7 +85,23 @@ body {
 .hero-section {
   padding: 2.25rem 0 2rem;
 
-  h2.hero-headline {
+  h1.hero-name {
+    font-size: 2.35rem;
+    line-height: 1.05;
+    color: $headings-color;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+  }
+
+  .hero-subhead {
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: lighten($secondary, 24%);
+    margin-bottom: 1rem;
+  }
+
+  .hero-headline {
     font-size: 1.7rem;
     line-height: 1.24;
     color: $headings-color;
@@ -103,6 +119,18 @@ body {
 
   .btn {
     min-width: 9.5rem;
+  }
+}
+
+.hero-social {
+  a {
+    color: lighten($secondary, 10%);
+    font-size: 1.15rem;
+    text-decoration: none;
+  }
+
+  a:hover {
+    color: $primary;
   }
 }
 
@@ -492,7 +520,11 @@ h2.section-heading {
   .hero-section {
     padding: 1rem 0 1.5rem;
 
-    h2.hero-headline {
+    h1.hero-name {
+      font-size: 2rem;
+    }
+
+    .hero-headline {
       font-size: 1.45rem;
       max-width: none;
     }


### PR DESCRIPTION
## What changed

This PR tightens the public-site positioning across the homepage, CV, Selected Work, and Writing pages.

- Refined the homepage structure around a clearer hero hierarchy and reduced repeated proof/content.
- Improved the contact flow with reply-time guidance and lightweight intake prompts.
- Reworked the CV opening so it better matches the homepage positioning.
- Narrowed the Writing page to longer-form essays and case studies, with short notes split out to `TIL / Random Notes`.
- Removed broader inspection/fashion emphasis from the main homepage and Selected Work positioning.
- Added styling support for the updated hero, fit cards, and contact/intake elements.

## Why it changed

The public site had a few positioning and presentation issues:

- the homepage repeated the core value proposition too much
- the Writing page mixed flagship essays with shorter notes, which diluted the narrative
- the CV still reflected an older, broader positioning than the homepage
- the contact flow needed a more concrete, lower-friction first step

## User impact

The site now reads more consistently as premium enterprise data / coding-agent / time-series consulting:

- clearer homepage message
- less duplicate proof and less mixed positioning
- stronger alignment between homepage, Selected Work, Writing, and CV
- more concrete contact expectations

## Root cause

The earlier content refresh improved some surfaces but left older structure and broader portfolio emphasis in place on others, especially the CV and Writing feed composition.

## Validation

- `quarto render`
- inspected generated HTML in `_site`
- visually checked rendered homepage and Writing page screenshots using headless Chrome
